### PR TITLE
chore: bump target and compile SDK to 35 for Android 15 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,10 +25,10 @@ if (useManagedAndroidSdkVersions) {
     }
   }
   project.android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 34)
+    compileSdkVersion safeExtGet("compileSdkVersion", 35)
     defaultConfig {
       minSdkVersion safeExtGet("minSdkVersion", 21)
-      targetSdkVersion safeExtGet("targetSdkVersion", 34)
+      targetSdkVersion safeExtGet("targetSdkVersion", 35)
     }
   }
 }


### PR DESCRIPTION
**Adds support for Android 15 (API level 35) by updating:**
- compileSdkVersion → 35
- targetSdkVersion → 35


Reported here : https://github.com/VNDRN/react-native-navigation-bar-detector/issues/4